### PR TITLE
Version 2.2.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Depends:
 Imports:
     findpython,
     jsonlite,
-    R6
+    R6,
+    utils
 SystemRequirements: python (>= 3.2)
 Suggests:
     knitr (>= 1.15.19),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: argparse
 Type: Package
 Title: Command Line Optional and Positional Argument Parser
-Version: 2.2.3
-Authors@R: c(person("Trevor L", "Davis", role=c("aut", "cre"),
+Version: 2.2.4-0
+Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")),
     person("Allen", "Day", role="ctb", comment="Some documentation and examples ported from the getopt package."),
@@ -28,5 +28,6 @@ Suggests:
     rmarkdown,
     testthat
 VignetteBuilder: knitr
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+argparse 2.2.4
+==============
+
+* `ArgumentParser()`'s `python_cmd` argument is now wrapped by `normalizePath(mustWork = FALSE)`.
+
 argparse 2.2.3
 ==============
 

--- a/R/argparse.R
+++ b/R/argparse.R
@@ -22,22 +22,22 @@
 
 #' Create a command line parser
 #'
-#' \code{ArgumentParser} creates a parser object that acts as
-#' a wrapper to Python's argparse module
+#' `ArgumentParser()` creates a parser object that acts as
+#' a wrapper to Python's `argparse` module
 #'
-#' @param ... Arguments cleaned and passed to Pythons argparse.ArgumentParser()
-#' @param python_cmd Python executable for \code{argparse} to use.
-#'      Must have argparse and json modules (automatically included Python 2.7 and 3.2+).
+#' @param ... Arguments cleaned and passed to Pythons `argparse.ArgumentParser()`
+#' @param python_cmd Python executable for `argparse` to use.
+#'      Must have `argparse` and `json` modules (automatically bundled with Python 2.7 and 3.2+).
 #'      If you need Unicode argument support then you must use Python 3.0+.
-#'      Default will be to use \code{findpython} package to find suitable Python binary.
-#' @return  \code{ArgumentParser} returns a parser object which contains
-#'    an \code{add_argument} function to add arguments to the parser,
-#'    a \code{parse_args} function to parse command line arguments into
-#'    a list, a \code{print_help} and \code{print_usage} function to print
+#'      Default will be to use `findpython` package to find suitable Python binary.
+#' @return  `ArgumentParser()` returns a parser object which contains
+#'    an `add_argument()` function to add arguments to the parser,
+#'    a `parse_args()` function to parse command line arguments into
+#'    a list, a `print_help()` and a `print_usage()` function to print
 #'    usage information.  See code examples, package vignette,
 #'    and corresponding python module for more information on how to use it.
 #'
-#' @references Python's \code{argparse} library, which this package is based on,
+#' @references Python's `argparse` library, which this package is based on,
 #'  is described here: \url{https://docs.python.org/3/library/argparse.html}
 #'
 #' @examples
@@ -392,6 +392,7 @@ find_python_cmd <- function(python_cmd = NULL) {
             python_cmd <- findpython::find_python_cmd(required_modules = required_modules)
         }
     }
+    python_cmd <- normalizePath(python_cmd, mustWork = FALSE)
     python_cmd
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,12 @@
+# Based on code from Dirk Eddelbuettel
+# https://fosstodon.org/@eddelbuettel@mastodon.social/113499555242268476
+get_linux_flavor <- function() {
+    flavor <- NA_character_
+    osrel <- "/etc/os-release"
+    if (isTRUE(file.exists(osrel))) {   # on (at least) Debian, Ubuntu, Fedora
+        x <- utils::read.table(osrel, sep = "=", row.names = 1L,
+                               col.names = c("","Val"), header = FALSE)
+        flavor <- tolower(x["ID", "Val"])
+    }
+    flavor
+}

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,5 @@ destination: "../../websites/R/argparse/"
 url: "https://trevorldavis.com/R/argparse"
 development:
     mode: auto
+template:
+  bootstrap: 5

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,9 @@
 ## Notes
 
+* Skips two `parse_known_intermixed_args()` tests on CRAN on Debian Testing
+  to avoid raising an ERROR due to a bug in Debian Testing's version of python:
+  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087681
+
 * As in previous uploads while in a non-interactive session (i.e. in an
   Rscript) if ``parse_args()`` observes a help flag it will print a usage
   message and then call ``quit()``.  Additionally if a user specifically adds
@@ -12,7 +16,7 @@
 
 ## Test environments
 
-* local (linux), R 4.3.3
+* local (linux), R 4.4.2
 * win-builder (windows), R devel
 * Github Actions (linux), R devel, release, oldrel
 * Github Actions (windows), R release
@@ -24,7 +28,7 @@ Status: OK
 
 ## revdepcheck results
 
-We checked 3 reverse dependencies (0 from CRAN + 3 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 4 reverse dependencies (0 from CRAN + 4 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages

--- a/man/ArgumentParser.Rd
+++ b/man/ArgumentParser.Rd
@@ -7,24 +7,24 @@
 ArgumentParser(..., python_cmd = NULL)
 }
 \arguments{
-\item{...}{Arguments cleaned and passed to Pythons argparse.ArgumentParser()}
+\item{...}{Arguments cleaned and passed to Pythons \code{argparse.ArgumentParser()}}
 
 \item{python_cmd}{Python executable for \code{argparse} to use.
-Must have argparse and json modules (automatically included Python 2.7 and 3.2+).
+Must have \code{argparse} and \code{json} modules (automatically bundled with Python 2.7 and 3.2+).
 If you need Unicode argument support then you must use Python 3.0+.
 Default will be to use \code{findpython} package to find suitable Python binary.}
 }
 \value{
-\code{ArgumentParser} returns a parser object which contains
-   an \code{add_argument} function to add arguments to the parser,
-   a \code{parse_args} function to parse command line arguments into
-   a list, a \code{print_help} and \code{print_usage} function to print
-   usage information.  See code examples, package vignette,
-   and corresponding python module for more information on how to use it.
+\code{ArgumentParser()} returns a parser object which contains
+an \code{add_argument()} function to add arguments to the parser,
+a \code{parse_args()} function to parse command line arguments into
+a list, a \code{print_help()} and a \code{print_usage()} function to print
+usage information.  See code examples, package vignette,
+and corresponding python module for more information on how to use it.
 }
 \description{
-\code{ArgumentParser} creates a parser object that acts as
-a wrapper to Python's argparse module
+\code{ArgumentParser()} creates a parser object that acts as
+a wrapper to Python's \code{argparse} module
 }
 \examples{
 
@@ -45,5 +45,5 @@ if (argparse:::detects_python()) {
 }
 \references{
 Python's \code{argparse} library, which this package is based on,
- is described here: \url{https://docs.python.org/3/library/argparse.html}
+is described here: \url{https://docs.python.org/3/library/argparse.html}
 }

--- a/tests/testthat/test-argparse.R
+++ b/tests/testthat/test-argparse.R
@@ -169,7 +169,18 @@ test_that("parse_intermixed_args() works as expected", {
     expect_equal(args$cmd, 'doit')
     expect_equal(args$foo, 'bar')
     expect_equal(args$rest, 1:3)
+})
 
+test_that("parse_known_intermixed_args() works as expected", {
+    skip_if_not(detects_python(minimum_version = '3.7'))
+    # Bug in Debian Testing's version of python causes CRAN ERROR
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087681
+    if (isTRUE(get_linux_flavor() == "debian"))
+        skip_on_cran()
+    parser <- ArgumentParser()
+    parser$add_argument('--foo')
+    parser$add_argument('cmd')
+    parser$add_argument('rest', nargs='*', type='integer')
     args <- strsplit('doit 1 --foo bar 2 3 -n 4', ' ')[[1]]
     a_r <- parser$parse_known_intermixed_args(args)
     expect_equal(a_r[[1]]$cmd, 'doit')


### PR DESCRIPTION
* `ArgumentParser()`'s `python_cmd` argument is now wrapped by `normalizePath(mustWork = FALSE)`.
* Skips two `parse_known_intermixed_args()` tests on CRAN on Debian Testing   to avoid raising an ERROR due to a bug in Debian Testing's version of python:   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087681

closes #53 
